### PR TITLE
Convert to Swift 2.2

### DIFF
--- a/NSDate_Extensions.xcodeproj/project.pbxproj
+++ b/NSDate_Extensions.xcodeproj/project.pbxproj
@@ -180,7 +180,9 @@
 		DF5FA96E1B031C1900EFDA42 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastSwiftMigration = 0730;
+				LastSwiftUpdateCheck = 0730;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = "Joe Christopher Paul Amanse";
 				TargetAttributes = {
 					DF5FA9751B031C1900EFDA42 = {
@@ -304,6 +306,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -372,6 +375,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = NSDate_Extensions/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.joechristopherpaulamanse.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -382,6 +386,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = NSDate_Extensions/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.joechristopherpaulamanse.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -400,6 +405,7 @@
 				);
 				INFOPLIST_FILE = NSDate_ExtensionsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.joechristopherpaulamanse.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/NSDate_Extensions.app/NSDate_Extensions";
 			};
@@ -415,6 +421,7 @@
 				);
 				INFOPLIST_FILE = NSDate_ExtensionsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.joechristopherpaulamanse.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/NSDate_Extensions.app/NSDate_Extensions";
 			};

--- a/NSDate_Extensions/Info.plist
+++ b/NSDate_Extensions/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.joechristopherpaulamanse.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/NSDate_Extensions/NSDate+Comparable.swift
+++ b/NSDate_Extensions/NSDate+Comparable.swift
@@ -27,7 +27,8 @@
 
 import Foundation
 
-extension NSDate: Equatable {}
+//  Redundant conformance of 'NSDate' to protocol 'Equatable'
+//  extension NSDate: Equatable {}
 public func ==(lhs: NSDate, rhs: NSDate) -> Bool {
     return lhs.isEqualToDate(rhs)
 }

--- a/NSDate_Extensions/NSDate+Main.swift
+++ b/NSDate_Extensions/NSDate+Main.swift
@@ -57,7 +57,7 @@ extension NSTimeInterval {
         return self.days * 7
     }
     
-    func count(unit: NSDateUnit) -> Double {
+    func count(unit: NSDateUnit) -> NSTimeInterval {
         switch unit {
         case .Second:
             return self
@@ -94,6 +94,7 @@ extension NSDate {
         
         return NSCalendar.currentCalendar().dateFromComponents(components)
     }
+    
     class func dateWithYear(year: Int, month: Int, day: Int, hour: Int, minute: Int, andSecond second: Int) -> NSDate? {
         let components = NSDateComponents()
         components.month = month
@@ -111,6 +112,7 @@ extension NSDate {
         dateFormatter.dateFormat = format
         return dateFormatter.dateFromString(dateString)
     }
+    
     class func dateFromComponents(components: NSDateComponents) -> NSDate? {
         return NSCalendar.currentCalendar().dateFromComponents(components)
     }
@@ -118,9 +120,11 @@ extension NSDate {
     class func today() -> NSDate {
         return NSDate()
     }
+    
     class func yesterday() -> NSDate {
         return NSDate().dateByAddingTimeInterval(-1.days)
     }
+    
     class func tomorrow() -> NSDate {
         return NSDate().dateByAddingTimeInterval(1.days)
     }
@@ -139,43 +143,43 @@ extension NSDate {
     
     // MARK: Calendar Units
     var era: Int {
-        return calendar.component(.CalendarUnitEra, fromDate: self)
+        return calendar.component(.Era, fromDate: self)
     }
     var year: Int {
-        return calendar.component(.CalendarUnitYear, fromDate: self)
+        return calendar.component(.Year, fromDate: self)
     }
     var month: Int {
-        return calendar.component(.CalendarUnitMonth, fromDate: self)
+        return calendar.component(.Month, fromDate: self)
     }
     var day: Int {
-        return calendar.component(.CalendarUnitDay, fromDate: self)
+        return calendar.component(.Day, fromDate: self)
     }
     var hour: Int {
-        return calendar.component(.CalendarUnitHour, fromDate: self)
+        return calendar.component(.Hour, fromDate: self)
     }
     var minute: Int {
-        return calendar.component(.CalendarUnitMinute, fromDate: self)
+        return calendar.component(.Minute, fromDate: self)
     }
     var second: Int {
-        return calendar.component(.CalendarUnitSecond, fromDate: self)
+        return calendar.component(.Second, fromDate: self)
     }
     var weekday: Int {
-        return calendar.component(.CalendarUnitWeekday, fromDate: self)
+        return calendar.component(.Weekday, fromDate: self)
     }
     var weekdayOrdinal: Int {
-        return calendar.component(.CalendarUnitWeekdayOrdinal, fromDate: self)
+        return calendar.component(.WeekdayOrdinal, fromDate: self)
     }
     var quarter: Int {
-        return calendar.component(.CalendarUnitQuarter, fromDate: self)
+        return calendar.component(.Quarter, fromDate: self)
     }
     var weekOfMonth: Int {
-        return calendar.component(.CalendarUnitWeekOfMonth, fromDate: self)
+        return calendar.component(.WeekOfMonth, fromDate: self)
     }
     var weekOfYear: Int {
-        return calendar.component(.CalendarUnitWeekOfYear, fromDate: self)
+        return calendar.component(.WeekOfYear, fromDate: self)
     }
     var nanosecond: Int {
-        return calendar.component(.CalendarUnitNanosecond, fromDate: self)
+        return calendar.component(.Nanosecond, fromDate: self)
     }
     
     var isToday: Bool {

--- a/NSDate_Extensions/NSDate+Periods.swift
+++ b/NSDate_Extensions/NSDate+Periods.swift
@@ -85,7 +85,7 @@ extension NSDate {
             
             return calendar.dateFromComponents(components)!
         case .Month:
-            let daysInMonth = calendar.rangeOfUnit(.CalendarUnitDay, inUnit: .CalendarUnitMonth, forDate: self).length
+            let daysInMonth = calendar.rangeOfUnit(.Day, inUnit: .Month, forDate: self).length
             
             return NSDate.dateWithYear(year, month: month, day: daysInMonth, hour: 23, minute: 59, andSecond: 59)!
         case .Year:

--- a/NSDate_ExtensionsTests/Info.plist
+++ b/NSDate_ExtensionsTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.joechristopherpaulamanse.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Convert to Swift 2.2;
Comment “extension NSDate: Equatable {}” because “Redundant conformance of 'NSDate' to protocol 'Equatable'”
